### PR TITLE
functionality for converting RootQueryType

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2724,8 +2724,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.2.tgz",
       "integrity": "sha512-RwywHlpCRc3/Wh81MiCKun4ydaIFyW5Ea6JbL6sRCVx5q5irDw7pMXBUFYF/jArQ6YrG36q0kpovc9P/Kd3I4g==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "boxen": {
       "version": "4.2.0",
@@ -4053,9 +4052,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.19.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
-          "integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw==",
+          "version": "12.19.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
+          "integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babili-webpack-plugin": "^0.1.2",
     "concurrently": "^5.3.0",
     "css-loader": "^5.0.1",
-    "electron": "^11.2.1",
+    "electron": "^11.2.2",
     "electron-devtools-installer": "^3.1.1",
     "electron-packager": "^15.2.0",
     "file-loader": "^6.2.0",


### PR DESCRIPTION
**Schema.js**
![switch](https://user-images.githubusercontent.com/34779156/107101395-2b815500-67e5-11eb-8dc2-02b0929e3dc7.JPG)
- Created switch statement for dynamic creation of specific graphql types. 

![object types](https://user-images.githubusercontent.com/34779156/107101417-43f16f80-67e5-11eb-8451-ec4ef22b99f8.JPG)
- dynamically generated fields object in RootQueryType 

**TODO:**
- add/fix resolvers in object types for "ref" in mongodb schema
- add findall and findbyID functionality in RootQueryType